### PR TITLE
Fix event timestamps not aligning to actual realtime

### DIFF
--- a/Packages/jp.keijiro.minis/Runtime/Internal/MidiUtility.cs
+++ b/Packages/jp.keijiro.minis/Runtime/Internal/MidiUtility.cs
@@ -1,7 +1,5 @@
-using System;
-using System.Reflection;
-using UnityEngine;
 using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.LowLevel;
 
 namespace Minis {
 
@@ -29,13 +27,7 @@ static class MidiUtility
 
     // Access to the internal current time property in Input System
     public static double GetTime()
-    {
-        var inputSystemType = Type.GetType
-          ("UnityEngineInternal.Input.NativeInputSystem, UnityEngine");
-        var currentTimeProperty = inputSystemType.GetProperty
-          ("currentTime", BindingFlags.Public | BindingFlags.Static);
-        return (double)currentTimeProperty.GetValue(null);
-    }
+      => InputState.currentTime;
 }
 
 } // namespace Minis


### PR DESCRIPTION
In the editor, the input system uses an internal time offset which is adjusted whenever play mode is entered or exited. This offset is used to make the 0 point of input timestamps match the time at which the last play mode transition happened.

The current method of grabbing input time bypasses this offset by using reflection to access an internal property. Without this offset, timestamps will never be in sync while in the editor, and will continually drift more and more each time play mode is entered.

https://github.com/user-attachments/assets/c75f0227-1fd7-4e02-9d77-9e4abf996568

The publicly-accessible `InputState.currentTime` property accounts for this offset, and so do the `InputSystem.Queue*Event` family of functions. Using that instead fixes this issue.

https://github.com/user-attachments/assets/efd2d836-c1d1-4222-9fd5-78261addadeb